### PR TITLE
refactor(workers): moved SQL to const

### DIFF
--- a/lib/task-queue/WorkerTask.js
+++ b/lib/task-queue/WorkerTask.js
@@ -115,10 +115,12 @@ class WorkerTask {
   static asyncSave(task) {
     // SQL to insert a new task
     const insertSQL = `INSERT INTO moz_tasks (pageUrl, createdAt, jobStartedAt, status, type)
-                       VALUES (:pageUrl, :createdAt, :jobStartedAt, :status, :type);SELECT last_insert_rowid() FROM moz_tasks;`;
+                       VALUES (:pageUrl, :createdAt, :jobStartedAt, :status, :type);`;
     // SQL to update an existing task
     const updateSQL = `UPDATE moz_tasks SET pageUrl = :pageUrl, createdAt = :createdAt,
                        jobStartedAt = :jobStartedAt, status = :status, type = :type WHERE id = :id`;
+    // SQL to select the id of the inserted task
+    const idSelectSQL = "select last_insert_rowid() FROM moz_tasks";
     // Query parameters
     let params = {
       pageUrl: task.pageUrl,
@@ -144,7 +146,7 @@ class WorkerTask {
       // If the task is new and doesn't have an id we want to
       // recover the auto-incremented id value from the database.
       if (!task.id) {
-        yield storage.asyncExecuteCached("Recovering task id", "select last_insert_rowid() FROM moz_tasks", {callback: (row)=> {
+        yield storage.asyncExecuteCached("Recovering task id", idSelectSQL, {callback: (row)=> {
           task.id = row.getResultByName("last_insert_rowid()");
         }});
       }


### PR DESCRIPTION
Moved the id selecting SQL to it's own constant and removed useless duplicate query from insert SQL.