### PR TITLE
chore(worker): change Firefox version to the same on Activity Stream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - node_modules
 
 addons:
-  firefox: "47.0"
+  firefox: "46.0"
 
 before_install:
   # see https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI


### PR DESCRIPTION
It seems the `yield expression must be parenthesized` errors I was getting at version 46 were only happening when other errors happened. It hides the real error, so it makes debugging harder. I think it would be a good idea to update the AS Firefox version from time to time.